### PR TITLE
Add warning and critical settings to output as Nagios performance data

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -258,9 +258,9 @@ diffseconds=$((expseconds-nowseconds))
 expdays=$((diffseconds/86400))
 
 # Trigger alarms if applicable
-[ $expdays -lt 0 ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain expired on $expiration.|Warning: $warning, Critical: $critical"
-[ $expdays -lt $critical ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain will expire in $expdays days ($expdate).|Warning: $warning, Critical: $critical"
-[ $expdays -lt $warning ] && die "$STATE_WARNING" "WARNING - Domain $domain will expire in $expdays days ($expdate).|Warning: $warning, Critical: $critical"
+[ $expdays -lt 0 ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain expired on $expiration. | domain_days_until_expiry=$expdays;$warning;$critical"
+[ $expdays -lt $critical ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
+[ $expdays -lt $warning ] && die "$STATE_WARNING" "WARNING - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
 
 # No alarms? Ok, everything is right.
-die "$STATE_OK" "OK - Domain $domain will expire in $expdays days ($expdate).|Warning: $warning, Critical: $critical"
+die "$STATE_OK" "OK - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -212,6 +212,9 @@ expiration=$(
 	# Registrar Registration Expiration Date: 2018-09-21 00:00:00 -0400
 	$0 ~ "Expiration Date: " DATE_ISO_LIKE {split($0, a, ":"); s = a[2]; if (split(s,d,/T/)) print d[1]; exit}
 
+	# Data de expiração / Expiration Date (dd/mm/yyyy): 18/01/2016
+	$0 ~ "Expiration Date \(dd/mm/yyyy\)" {split($NF, a, "/"); printf("%s-%s-%s", a[3], a[2], a[1]); exit}
+
 	# Domain Expiration Date: Wed Mar 02 23:59:59 GMT 2016
 	$0 ~ "Expiration Date: *" DATE_DAY_MON_DD_HHMMSS_TZ_YYYY {
 		printf("%s-%s-%s", $9, mon2moy($5), $6);

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,7 @@ amazon.ie
 autoproff.gl
 autoproff.ir
 autoproff.pl
+autoproff.pt
 autoproff.si
 bbk.ac.uk
 cnn.com


### PR DESCRIPTION
I use different warning and critical values for different domains and sometimes forget what I set them to. This lets you find that info on the service details screen without clogging up the main info.

Besides, the Performance Data field is there whether there's anything in it or not; we might as well put it to good use.