### PR TITLE
Parse .edu domains correctly.

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -176,6 +176,10 @@ expiration=$(
 	# Expiry date:  05-Dec-2014
 	/Expir(y|ation) [Dd]ate:/ && $NF ~ DATE_DD_MON_YYYY {split($3, a, "-"); printf("%s-%s-%s\n", a[3], mon2moy(a[2]), a[1]); exit}
 
+	# expires:      05-Dec-2014
+	/expires:/ && $NF ~ DATE_DD_MON_YYYY {split($3, a, "-"); printf("%s-%s-%s\n", a[3], mon2moy(a[2]), a[1]); exit}
+
+
 	# Expiry Date: 19/11/2015
 	/Expiry Date:/ && $NF ~ DATE_DD_MM_YYYY_SLASH {split($3, a, "/"); printf("%s-%s-%s", a[3], a[2], a[1]); exit}
 

--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,7 @@ delfi.ee
 delfi.tv
 dk-hostmaster.dk
 drop.io
+educause.edu
 getsynced.co
 gimp.org
 google.com


### PR DESCRIPTION
All edu domains (using the educause.edu whois server), receive an error similar to:

-> educause.edu
date: invalid date `--31-Jul-2015'

So, I just added another case in the awk script for this output type.