### PR TITLE
Fix logic for alerts for domains with negative values for  and/or .

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -308,9 +308,8 @@ nowseconds=$(date +%s)
 diffseconds=$((expseconds-nowseconds))
 expdays=$((diffseconds/86400))
 
-# Trigger alarms if applicable in the case that both $warning and $critical are positive
-if [ $warning -ge 0 ] && [ $critical -ge 0 ]; then
-	[ $expdays -lt 0 ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain expired on $expiration. | domain_days_until_expiry=$expdays;$warning;$critical"
+# Trigger alarms (if applicable) if the domain is not expired.
+if [ $expdays -ge 0 ]; then
 	[ $expdays -lt $critical ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
 	[ $expdays -lt $warning ] && die "$STATE_WARNING" "WARNING - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
 


### PR DESCRIPTION
Previously, if you used negative values for either $warning or $critical, BUT the domain had not expired, it would say "The domain expired in $expdays" when it should say "The domain will expire in $expdays". Now this logic is fixed. (Sorry!)