### PR TITLE
Shellcheck

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -81,7 +81,8 @@ EOF
 # create tempfile. as secure as possible
 # tempfile name is returned to stdout
 tempfile() {
-	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}"/check_domain."$RANDOM".$$
+	random=$(awk -v min=100000 -v max=999999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')
+	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}"/check_domain."$random".$$
 }
 
 while :; do

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -38,8 +38,8 @@ fi
 set -- "$args"
 
 die() {
-	local rc=$1
-	local msg="$2"
+	rc=$1
+	msg="$2"
 	echo "$msg"
 	test "$outfile" && rm -f "$outfile"
 	exit "$rc"

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -20,7 +20,7 @@ PROGRAM=${0##*/}
 VERSION=1.4.5
 PROGPATH=${0%/*}
 # shellcheck source=/dev/null
-. $PROGPATH/utils.sh
+. "$PROGPATH/utils.sh"
 
 # Default values (days):
 critical=7

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -19,6 +19,7 @@ set -e
 PROGRAM=${0##*/}
 VERSION=1.4.5
 PROGPATH=${0%/*}
+# shellcheck source=/dev/null
 . $PROGPATH/utils.sh
 
 # Default values (days):

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -110,7 +110,7 @@ if [ -n "$whoispath" ]; then
 	fi
 	[ -n "$whois" ] || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary, you specified an incorrect path"
 else
-	type whois > /dev/null 2>&1 || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary in your path. Is it installed? Please specify path."
+	echo whois > /dev/null 2>&1 || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary in your path. Is it installed? Please specify path."
 	whois=whois
 fi
 


### PR DESCRIPTION
Fix a few warnings that pop up when running it through shellcheck.net. Each commit is for a specific error so it can be traced.

Note: I had to swap all the single-quotes for double-quotes in the awk part. This makes it look like I made major changes. This was to fix "Double quote to prevent globbing and word splitting" for variables.