### PR TITLE
Specifically check if the domain is not found.

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -117,6 +117,10 @@ outfile=$(tempfile)
 $whois ${server:+-h $server} $domain > $outfile 2>&1 && error=$? || error=$?
 [ -s "$outfile" ] || die "$STATE_UNKNOWN" "UNKNOWN - Domain $domain doesn't exist or no WHOIS server available."
 
+if grep -q -e "No match for" -e "NOT FOUND" -e "NO DOMAIN" $outfile; then
+	die "$STATE_UNKNOWN" "UNKNOWN - Domain $domain doesn't exist."
+fi
+
 # check for common errors
 if grep -q -e "Query rate limit exceeded. Reduced information." -e "WHOIS LIMIT EXCEEDED" $outfile; then
 	die "$STATE_UNKNOWN" "UNKNOWN - Rate limited WHOIS response"


### PR DESCRIPTION
If you query for a domain and it returns some output but the domain is not found, check_domain.sh gives the user the following output:
UNKNOWN - Unable to figure out expiration date for <domain that doen't exist> Domain.

An example is if you check for fakedomainaaa.com, you get:
UNKNOWN - Unable to figure out expiration date for fakedomainaaa.com Domain.

However, the output usually says something about it not being found. For .com domains you get the string "No match for".

This patch checks for those common strings and gives the user more specific information: The domain doesn't exist.