### PR TITLE
Shellcheck

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -20,7 +20,7 @@ PROGRAM=${0##*/}
 VERSION=1.4.5
 PROGPATH=${0%/*}
 # shellcheck source=/dev/null
-. $PROGPATH/utils.sh
+. "$PROGPATH/utils.sh"
 
 # Default values (days):
 critical=7
@@ -29,7 +29,7 @@ warning=30
 awk=${AWK:-awk}
 
 # Parse arguments
-args=$(getopt -o hd:w:c:P:s: --long help,domain:,warning:,critical:,path:,server: -u -n $PROGRAM -- "$@")
+args=$(getopt -o hd:w:c:P:s: --long help,domain:,warning:,critical:,path:,server: -u -n "$PROGRAM" -- "$@")
 if [ $? != 0 ]; then
 	echo >&2 "$PROGRAM: Could not parse arguments"
 	echo "Usage: $PROGRAM -h | -d <domain> [-c <critical>] [-w <warning>] [-P <path_to_whois>] [-s <server>]"
@@ -42,7 +42,7 @@ die() {
 	msg="$2"
 	echo "$msg"
 	test "$outfile" && rm -f "$outfile"
-	exit $rc
+	exit "$rc"
 }
 
 fullusage() {
@@ -82,7 +82,7 @@ EOF
 # tempfile name is returned to stdout
 tempfile() {
 	random=$(awk -v min=100000 -v max=999999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')
-	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}"/check_domain.$random.$$
+	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}"/check_domain."$random".$$
 }
 
 while :; do
@@ -98,7 +98,7 @@ while :; do
 	esac
 done
 
-if [ -z $domain ]; then
+if [ -z "$domain" ]; then
 	die "$STATE_UNKNOWN" "UNKNOWN - There is no domain name to check"
 fi
 
@@ -116,14 +116,14 @@ else
 fi
 
 outfile=$(tempfile)
-$whois ${server:+-h $server} $domain > $outfile 2>&1 && error=$? || error=$?
+$whois ${server:+-h $server} "$domain" > "$outfile" 2>&1 && error=$? || error=$?
 [ -s "$outfile" ] || die "$STATE_UNKNOWN" "UNKNOWN - Domain $domain doesn't exist or no WHOIS server available."
 
 # check for common errors
-if grep -q -e "Query rate limit exceeded. Reduced information." -e "WHOIS LIMIT EXCEEDED" $outfile; then
+if grep -q -e "Query rate limit exceeded. Reduced information." -e "WHOIS LIMIT EXCEEDED" "$outfile"; then
 	die "$STATE_UNKNOWN" "UNKNOWN - Rate limited WHOIS response"
 fi
-if grep -q -e "fgets: Connection reset by peer" $outfile; then
+if grep -q -e "fgets: Connection reset by peer" "$outfile"; then
 	error=0
 fi
 
@@ -303,7 +303,7 @@ expiration=$(
 	# Monday 21st Sep 2015
 	/Renewal date:/{renewal = 1; next}
 	{if (renewal) { sub(/[^0-9]+/, "", $2); printf("%s-%s-%s", $4, mon2moy($3), $2); exit}}
-' $outfile)
+' "$outfile")
 
 [ -z "$expiration" ] && die "$STATE_UNKNOWN" "UNKNOWN - Unable to figure out expiration date for $domain Domain."
 
@@ -315,15 +315,15 @@ expdays=$((diffseconds/86400))
 
 # Trigger alarms (if applicable) if the domain is not expired.
 if [ $expdays -ge 0 ]; then
-	[ $expdays -lt $critical ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
-	[ $expdays -lt $warning ] && die "$STATE_WARNING" "WARNING - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
+	[ $expdays -lt "$critical" ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
+	[ $expdays -lt "$warning" ] && die "$STATE_WARNING" "WARNING - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
 
 	# No alarms? Ok, everything is right.
 	die "$STATE_OK" "OK - Domain $domain will expire in $expdays days ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
 fi
 
 # Trigger alarms if applicable in the case that $warning and/or $critical are negative
-[ $expdays -lt $critical ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain expired ${expdays#-} days ago ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
-[ $expdays -lt $warning ] && die "$STATE_WARNING" "WARNING - Domain $domain expired ${expdays#-} days ago ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
+[ $expdays -lt "$critical" ] && die "$STATE_CRITICAL" "CRITICAL - Domain $domain expired ${expdays#-} days ago ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
+[ $expdays -lt "$warning" ] && die "$STATE_WARNING" "WARNING - Domain $domain expired ${expdays#-} days ago ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"
 # No alarms? Ok, everything is right.
 die "$STATE_OK" "OK - Domain $domain expired ${expdays#-} days ago ($expdate). | domain_days_until_expiry=$expdays;$warning;$critical"

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -38,8 +38,8 @@ fi
 set -- $args
 
 die() {
-	rc="$1"
-	msg="$2"
+	local rc="$1"
+	local msg="$2"
 	echo "$msg"
 	test "$outfile" && rm -f "$outfile"
 	exit "$rc"

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -38,8 +38,8 @@ fi
 set -- $args
 
 die() {
-	local rc=$1
-	local msg="$2"
+	rc="$1"
+	msg="$2"
 	echo "$msg"
 	test "$outfile" && rm -f "$outfile"
 	exit $rc

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -19,6 +19,7 @@ set -e
 PROGRAM=${0##*/}
 VERSION=1.4.5
 PROGPATH=${0%/*}
+# shellcheck source=/dev/null
 . $PROGPATH/utils.sh
 
 # Default values (days):

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -111,7 +111,7 @@ if [ -n "$whoispath" ]; then
 	fi
 	[ -n "$whois" ] || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary, you specified an incorrect path"
 else
-	type whois > /dev/null 2>&1 || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary in your path. Is it installed? Please specify path."
+	echo whois > /dev/null 2>&1 || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary in your path. Is it installed? Please specify path."
 	whois=whois
 fi
 

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -81,7 +81,8 @@ EOF
 # create tempfile. as secure as possible
 # tempfile name is returned to stdout
 tempfile() {
-	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo ${TMPDIR:-/tmp}/check_domain.$RANDOM.$$
+	random=$(awk -v min=100000 -v max=999999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')
+	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}"/check_domain.$random.$$
 }
 
 while :; do

--- a/check_domain.sh
+++ b/check_domain.sh
@@ -81,8 +81,7 @@ EOF
 # create tempfile. as secure as possible
 # tempfile name is returned to stdout
 tempfile() {
-	random=$(awk -v min=100000 -v max=999999 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')
-	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo "${TMPDIR:-/tmp}"/check_domain."$random".$$
+	mktemp --tmpdir -t check_domainXXXXXX 2>/dev/null || echo ${TMPDIR:-/tmp}/check_domain.$RANDOM.$$
 }
 
 while :; do
@@ -111,7 +110,7 @@ if [ -n "$whoispath" ]; then
 	fi
 	[ -n "$whois" ] || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary, you specified an incorrect path"
 else
-	echo whois > /dev/null 2>&1 || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary in your path. Is it installed? Please specify path."
+	type whois > /dev/null 2>&1 || die "$STATE_UNKNOWN" "UNKNOWN - Unable to find whois binary in your path. Is it installed? Please specify path."
 	whois=whois
 fi
 


### PR DESCRIPTION
Fixed a few things shellcheck.net recommended.

Not fixed:
Line 38: `set -- $args`
[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) Double quote to prevent globbing and word splitting.

Line 134: `$awk '`
[SC2016](https://github.com/koalaman/shellcheck/wiki/SC2016) Expressions don't expand in single quotes, use double quotes for that.

This is for issue #49.